### PR TITLE
Wrap long chat messages

### DIFF
--- a/public/elements/pugchamp-chat/pugchamp-chat.html
+++ b/public/elements/pugchamp-chat/pugchamp-chat.html
@@ -36,6 +36,10 @@
                 margin-right: 5px;
             }
 
+            .message .message-contents {
+                overflow: hidden;
+            }
+
             .message .message-author {
                 @apply(--paper-font-body2);
             }
@@ -55,7 +59,7 @@
             <template is="dom-repeat" items="{{messages}}">
                 <paper-material class="message horizontal layout">
                     <div class="message-time">{{formatTime(item.time)}}</div>
-                    <div class="flex">
+                    <div class="flex message-contents">
                         <template is="dom-if" if="{{item.user}}">
                             <span class="message-author"><iron-icon hidden$="{{!item.user.admin}}" icon="flag"></iron-icon> {{item.user.alias}}</span>
                         </template>


### PR DESCRIPTION
Before:
![pugchamp-msg-before](https://cloud.githubusercontent.com/assets/1004194/13001792/47928a60-d137-11e5-85f8-4eea95cd9f9d.png)

After:
![pugchamp-msg-after](https://cloud.githubusercontent.com/assets/1004194/13001793/49b09332-d137-11e5-9fa3-3a3f6f084f56.png)

An overflow other than visible needs to be set on the block-level
container to force line wrapping to occur (otherwise line boxes are
allowed to extend beyond the end of their container, regardless of
overflow-wrap: break-word)

Tested on latest FF and Chrome Stable+Canary
